### PR TITLE
add: use blsttc instead of threshold_crypto #4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ itertools = "~0.9.0"
 thiserror = "1.0.23"
 
   [dependencies.bls]
-  package = "threshold_crypto"
-  version = "~0.4.0"
+  package = "blsttc"
+  version = "1.0.1"
 
   [dependencies.serde]
   version = "1.0.117"


### PR DESCRIPTION
- fixes dependency deprecation warning with `failure` crate #4
- blsttc is faster than threshold_crypto