### PR TITLE
chore: upgrade blsttc to 6.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,7 @@ edition = "2018"
 
 [dependencies]
 bincode = "1.2.1"
+bls = { package = "blsttc", version = "6.0.0" }
 itertools = "~0.9.0"
+serde = { version = "1.0.117", features = ["derive"] }
 thiserror = "1.0.23"
-
-  [dependencies.bls]
-  package = "blsttc"
-  version = "5.2.0"
-
-  [dependencies.serde]
-  version = "1.0.117"
-  features = [ "derive" ]


### PR DESCRIPTION
Crates in the `safe_network` workspace will be getting upgraded to use this new version of blsttc,
so this dependent crate also needs to be upgraded.

The references in the Cargo manifest were changed to the short-form style, since there doesn't seem
to be a reason to preference the long-form style unless the line length is getting large.