### PR TITLE
chore: upgrade blsttc to 7.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = "1.0.23"
 
   [dependencies.bls]
   package = "blsttc"
-  version = "6.0.0"
+  version = "7.0.0"
 
   [dependencies.serde]
   version = "1.0.117"


### PR DESCRIPTION
Crates in the `safe_network` workspace will be getting upgraded to use this new version of blsttc, so this dependent crate also needs to be upgraded.